### PR TITLE
Deploy nuget version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 
 
 
-## [1.1.1] - 2022-03-20
-[Full Changelog](https://github.com/TechNobre/PowerUtils.GuardClauses.Validations/compare/v1.1.0...v1.1.1)
+## [1.2.0] - 2022-03-20
+[Full Changelog](https://github.com/TechNobre/PowerUtils.GuardClauses.Validations/compare/v1.1.0...v1.2.0)
+
+
+### New Features
+- Added Guard `Guard.Validate.IfEquals()`;
+- Added Guard `Guard.Validate.IfDifferent()`;
 
 
 ### Enhancements
@@ -12,6 +17,7 @@
 - Discontinued the validation `string.IfLengthDifference`, Can use the `string.IfLengthDifferent` because the name is wrong;
 - Discontinued the validation `string.IfLengthGreaterThan`, Can use the `string.IfLongerThan`. Improved method name;
 - Discontinued the validation `string.IfLengthLessThan`, Can use the `string.IfShorterThan`. Improved method name;
+- Discontinued the validation `string.NotEmail`, Can use the `string.IfNotEmail` because the name is wrong;
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 
 
 
+## [1.1.1] - 2022-03-20
+[Full Changelog](https://github.com/TechNobre/PowerUtils.GuardClauses.Validations/compare/v1.1.0...v1.1.1)
+
+
+### Enhancements
+- Discontinued the validation `string.IfLengthZero`, Can use the `string.IfEmpty` because it does the same validation;
+- Discontinued the validation `string.IfLengthDifference`, Can use the `string.IfLengthDifferent` because the name is wrong;
+
+
+
+
 ## [1.1.0] - 2022-03-16
 [Full Changelog](https://github.com/TechNobre/PowerUtils.GuardClauses.Validations/compare/v1.0.0...v1.1.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Enhancements
 - Discontinued the validation `string.IfLengthZero`, Can use the `string.IfEmpty` because it does the same validation;
 - Discontinued the validation `string.IfLengthDifference`, Can use the `string.IfLengthDifferent` because the name is wrong;
+- Discontinued the validation `string.IfLengthGreaterThan`, Can use the `string.IfLongerThan`. Improved method name;
+- Discontinued the validation `string.IfLengthLessThan`, Can use the `string.IfShorterThan`. Improved method name;
 
 
 

--- a/README.md
+++ b/README.md
@@ -95,25 +95,33 @@ dotnet add package PowerUtils.GuardClauses.Validations
   - `Guard.Validate.IfNullOrWhiteSpace()`;
   - `Guard.Validate.IfLongerThan()`;
   - `Guard.Validate.IfShorterThan()`;
-  - `Guard.Validate.NotEmail()`;
+  - `Guard.Validate.IfNotEmail()`;
   - `Guard.Validate.IfLengthEquals()`;
   - `Guard.Validate.IfLengthDifferent()`;
-- __int, uint, long, ulong, float, double, decimal:__
+  - `Guard.Validate.IfEquals()`;
+  - `Guard.Validate.IfDifferent()`;
+- __short, ushort, int, uint, long, ulong, float, double, decimal:__
   - `Guard.Validate.IfGreaterThan()`;
   - `Guard.Validate.IfLessThan()`;
+  - `Guard.Validate.IfEquals()`;
+  - `Guard.Validate.IfDifferent()`;
 - __DateTime:__
   - `Guard.Validate.IfGreaterThan()`;
   - `Guard.Validate.IfGreaterThanUtcNow()`;
   - `Guard.Validate.IfLessThan()`;
   - `Guard.Validate.IfLessThanUtcNow()`;
+  - `Guard.Validate.IfEquals()`;
+  - `Guard.Validate.IfDifferent()`;
 - __Guid:__
   - `Guard.Validate.IfEmpty()`;
+  - `Guard.Validate.IfEquals()`;
+  - `Guard.Validate.IfDifferent()`;
 
 
 
 
 ## :warning: Warning
-The methods `string.IfLengthZero`, `string.IfLengthDifferent`, `string.IfLengthGreaterThan`, `string.IfLengthLessThan` will be removed in 2021/05/31.
+The methods `string.IfLengthZero`, `string.IfLengthDifferent`, `string.IfLengthGreaterThan`, `string.IfLengthLessThan`, `string.NotEmail` will be removed in 2021/05/31.
 
 
 
@@ -121,6 +129,13 @@ The methods `string.IfLengthZero`, `string.IfLengthDifferent`, `string.IfLengthG
 ## Contribution
 
 *Help me to help others*
+
+
+
+
+## Credits
+
+[Ardalis.GuardClauses](https://github.com/ardalis/GuardClauses) and [Throw](https://github.com/mantinband/throw) - They are excellent libraries used as inspiration to develop this library.
 
 
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ dotnet add package PowerUtils.GuardClauses.Validations
   - `Guard.Validate.IfEmpty()`;
   - `Guard.Validate.IfNullOrEmpty()`;
   - `Guard.Validate.IfNullOrWhiteSpace()`;
-  - `Guard.Validate.IfLengthGreaterThan()`;
-  - `Guard.Validate.IfLengthLessThan()`;
+  - `Guard.Validate.IfLongerThan()`;
+  - `Guard.Validate.IfShorterThan()`;
   - `Guard.Validate.NotEmail()`;
   - `Guard.Validate.IfLengthEquals()`;
   - `Guard.Validate.IfLengthDifferent()`;
@@ -113,7 +113,7 @@ dotnet add package PowerUtils.GuardClauses.Validations
 
 
 ## :warning: Warning
-The methods `string.IfLengthZero`, `string.IfLengthDifferent` will be removed in 2021/05/31.
+The methods `string.IfLengthZero`, `string.IfLengthDifferent`, `string.IfLengthGreaterThan`, `string.IfLengthLessThan` will be removed in 2021/05/31.
 
 
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,9 @@ dotnet add package PowerUtils.GuardClauses.Validations
   - `Guard.Validate.IfNullOrWhiteSpace()`;
   - `Guard.Validate.IfLengthGreaterThan()`;
   - `Guard.Validate.IfLengthLessThan()`;
-  - `Guard.Validate.IfLengthZero()`;
   - `Guard.Validate.NotEmail()`;
   - `Guard.Validate.IfLengthEquals()`;
-  - `Guard.Validate.IfLengthDifference()`;
+  - `Guard.Validate.IfLengthDifferent()`;
 - __int, uint, long, ulong, float, double, decimal:__
   - `Guard.Validate.IfGreaterThan()`;
   - `Guard.Validate.IfLessThan()`;
@@ -109,6 +108,13 @@ dotnet add package PowerUtils.GuardClauses.Validations
   - `Guard.Validate.IfLessThanUtcNow()`;
 - __Guid:__
   - `Guard.Validate.IfEmpty()`;
+
+
+
+
+## :warning: Warning
+The methods `string.IfLengthZero`, `string.IfLengthDifferent` will be removed in 2021/05/31.
+
 
 
 

--- a/src/GuardClauses/GuardValidationDateTimeExtensions.cs
+++ b/src/GuardClauses/GuardValidationDateTimeExtensions.cs
@@ -171,5 +171,48 @@ namespace PowerUtils.Validations.GuardClauses
                 throw new PropertyException(parameterName, ErrorCodes.MIN_DATETIME_UTCNOW);
             }
         }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            DateTime? value,
+            DateTime? otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            DateTime? value,
+            DateTime? otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
     }
 }

--- a/src/GuardClauses/GuardValidationDecimalExtensions.cs
+++ b/src/GuardClauses/GuardValidationDecimalExtensions.cs
@@ -90,5 +90,48 @@ namespace PowerUtils.Validations.GuardClauses
                 throw new PropertyException(parameterName, ErrorCodes.GetMinFormatted(min));
             }
         }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            decimal? value,
+            decimal otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            decimal? value,
+            decimal otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
     }
 }

--- a/src/GuardClauses/GuardValidationDoubleExtensions.cs
+++ b/src/GuardClauses/GuardValidationDoubleExtensions.cs
@@ -90,5 +90,48 @@ namespace PowerUtils.Validations.GuardClauses
                 throw new PropertyException(parameterName, ErrorCodes.GetMinFormatted(min));
             }
         }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            double? value,
+            double otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            double? value,
+            double otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
     }
 }

--- a/src/GuardClauses/GuardValidationFloatExtensions.cs
+++ b/src/GuardClauses/GuardValidationFloatExtensions.cs
@@ -90,5 +90,48 @@ namespace PowerUtils.Validations.GuardClauses
                 throw new PropertyException(parameterName, ErrorCodes.GetMinFormatted(min));
             }
         }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            float? value,
+            float otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            float? value,
+            float otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
     }
 }

--- a/src/GuardClauses/GuardValidationGuidExtensions.cs
+++ b/src/GuardClauses/GuardValidationGuidExtensions.cs
@@ -24,5 +24,48 @@ namespace PowerUtils.Validations.GuardClauses
                 throw new PropertyException(parameterName, ErrorCodes.REQUIRED);
             }
         }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            Guid? value,
+            Guid? otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            Guid? value,
+            Guid? otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
     }
 }

--- a/src/GuardClauses/GuardValidationIntExtensions.cs
+++ b/src/GuardClauses/GuardValidationIntExtensions.cs
@@ -90,5 +90,48 @@ namespace PowerUtils.Validations.GuardClauses
                 throw new PropertyException(parameterName, ErrorCodes.GetMinFormatted(min));
             }
         }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            int? value,
+            int otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            int? value,
+            int otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
     }
 }

--- a/src/GuardClauses/GuardValidationLongExtensions.cs
+++ b/src/GuardClauses/GuardValidationLongExtensions.cs
@@ -90,5 +90,48 @@ namespace PowerUtils.Validations.GuardClauses
                 throw new PropertyException(parameterName, ErrorCodes.GetMinFormatted(min));
             }
         }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            long? value,
+            long otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            long? value,
+            long otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
     }
 }

--- a/src/GuardClauses/GuardValidationStringExtensions.cs
+++ b/src/GuardClauses/GuardValidationStringExtensions.cs
@@ -95,7 +95,23 @@ namespace PowerUtils.Validations.GuardClauses
         /// <param name="maxLength">Max length</param>
         /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
         /// <exception cref="PropertyException">Exception thrown when the length of the value is greater than</exception>
+        [System.Obsolete("This method is deprecated. It will be removed on 2022/09/30. Use the new method 'string.IfLongerThan'")]
         public static void IfLengthGreaterThan(
+            this IGuardClause _,
+            string value,
+            int maxLength,
+            [CallerArgumentExpression("value")] string parameterName = null
+        ) => Guard.Validate.IfLongerThan(value, maxLength, parameterName);
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is longer than. Error code 'MAX:{X}'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="maxLength">Max length</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when the value is longer than</exception>
+        public static void IfLongerThan(
             this IGuardClause _,
             string value,
             int maxLength,
@@ -121,7 +137,23 @@ namespace PowerUtils.Validations.GuardClauses
         /// <param name="minLength">Max length</param>
         /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
         /// <exception cref="PropertyException">Exception thrown when the length of the value is less than</exception>
+        [System.Obsolete("This method is deprecated. It will be removed on 2022/09/30. Use the new method 'string.IfShorterThan'")]
         public static void IfLengthLessThan(
+            this IGuardClause _,
+            string value,
+            int minLength,
+            [CallerArgumentExpression("value")] string parameterName = null
+        ) => Guard.Validate.IfShorterThan(value, minLength, parameterName);
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is shorter than. Error code 'MIN:{X}'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="minLength">Max length</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when the value is shorter than</exception>
+        public static void IfShorterThan(
             this IGuardClause _,
             string value,
             int minLength,

--- a/src/GuardClauses/GuardValidationStringExtensions.cs
+++ b/src/GuardClauses/GuardValidationStringExtensions.cs
@@ -146,6 +146,7 @@ namespace PowerUtils.Validations.GuardClauses
         /// <param name="value">Value to validate</param>
         /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
         /// <exception cref="PropertyException">Exception thrown when the length of the value is zero</exception>
+        [System.Obsolete("This method is deprecated. It will be removed on 2022/09/30. Use the new method 'string.IfEmpty'")]
         public static void IfLengthZero(
             this IGuardClause _,
             string value,
@@ -197,7 +198,23 @@ namespace PowerUtils.Validations.GuardClauses
         /// <param name="length">Valid length</param>
         /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
         /// <exception cref="PropertyException">Exception thrown when the length of the value is difference to parameter</exception>
+        [System.Obsolete("This method is deprecated. It will be removed on 2022/09/30. Use the new method 'string.IfLengthDifferent'")]
         public static void IfLengthDifference(
+            this IGuardClause _,
+            string value,
+            int length,
+            [CallerArgumentExpression("value")] string parameterName = null
+        ) => Guard.Validate.IfLengthDifferent(value, length, parameterName);
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> has a length different to parameter. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="length">Valid length</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when the length of the value is different to parameter</exception>
+        public static void IfLengthDifferent(
             this IGuardClause _,
             string value,
             int length,

--- a/src/GuardClauses/GuardValidationStringExtensions.cs
+++ b/src/GuardClauses/GuardValidationStringExtensions.cs
@@ -271,13 +271,70 @@ namespace PowerUtils.Validations.GuardClauses
         /// <param name="value">Value to validate</param>
         /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
         /// <exception cref="PropertyException">Exception thrown when the value is not an email</exception>
+        [System.Obsolete("This method is deprecated. It will be removed on 2022/09/30. Use the new method 'string.IfNotEmail'")]
         public static void NotEmail(
+            this IGuardClause _,
+            string value,
+            [CallerArgumentExpression("value")] string parameterName = null
+        ) => Guard.Validate.IfNotEmail(value, parameterName);
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is not an email. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when the value is not an email</exception>
+        public static void IfNotEmail(
             this IGuardClause _,
             string value,
             [CallerArgumentExpression("value")] string parameterName = null
         )
         {
             if(!value.IsEmail())
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            string value,
+            string otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            string value,
+            string otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
             {
                 throw new PropertyException(parameterName, ErrorCodes.INVALID);
             }

--- a/src/GuardClauses/GuardValidationUIntExtensions.cs
+++ b/src/GuardClauses/GuardValidationUIntExtensions.cs
@@ -90,5 +90,48 @@ namespace PowerUtils.Validations.GuardClauses
                 throw new PropertyException(parameterName, ErrorCodes.GetMinFormatted(min));
             }
         }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            uint? value,
+            uint otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            uint? value,
+            uint otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
     }
 }

--- a/src/GuardClauses/GuardValidationULongExtensions.cs
+++ b/src/GuardClauses/GuardValidationULongExtensions.cs
@@ -90,5 +90,48 @@ namespace PowerUtils.Validations.GuardClauses
                 throw new PropertyException(parameterName, ErrorCodes.GetMinFormatted(min));
             }
         }
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is equals to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is equals to the other value</exception>
+        public static void IfEquals(
+            this IGuardClause _,
+            ulong? value,
+            ulong otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value == otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
+
+
+        /// <summary>
+        /// Throws an <see cref="PropertyException" /> if <paramref name="value"/> is different to other value. Error code 'INVALID'
+        /// </summary>
+        /// <param name="_"></param>
+        /// <param name="value">Value to validate</param>
+        /// <param name="otherValue">Reference value for comparison</param>
+        /// <param name="parameterName">If not defined, the name of the variable passed by the <paramref name="value"/> parameter will be used</param>
+        /// <exception cref="PropertyException">Exception thrown when value is different to the other value</exception>
+        public static void IfDifferent(
+            this IGuardClause _,
+            ulong? value,
+            ulong otherValue,
+            [CallerArgumentExpression("value")] string parameterName = null
+        )
+        {
+            if(value != otherValue)
+            {
+                throw new PropertyException(parameterName, ErrorCodes.INVALID);
+            }
+        }
     }
 }

--- a/src/PowerUtils.GuardClauses.Validations.csproj
+++ b/src/PowerUtils.GuardClauses.Validations.csproj
@@ -14,7 +14,7 @@
     <PackageId>PowerUtils.GuardClauses.Validations</PackageId>
     <title>PowerUtils.GuardClauses.Validations</title>
     <Product>PowerUtils.GuardClauses.Validations</Product>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
 
     <Authors>Nelson Nobre</Authors>
     <Company>TechNobre</Company>
@@ -25,27 +25,13 @@
 
     <Description>Helpers, extensions and utilities to work with guard clause</Description>
     <PackageReleaseNotes>
-      - Added Guard `Guard.Validate.IfEmpty(string)`;
-      - Added Guard `Guard.Validate.IfEmpty(guid)`;
-      - Added Guard `Guard.Validate.NotEmail(email)`;
-      - Added Guard `Guard.Validate.IfLengthEquals(value, length)`;
-      - Added Guard `Guard.Validate.IfLengthDifference(value, length)`;
-      - Added new constructor `UnauthorizedException(property, errorCode, message)`;
-      - Added new constructor `ForbiddenException(property, errorCode, message)`;
-      - Added new constructor `NotFoundException(property, errorCode, message)`;
-      - Added new constructor `ConflictException(property, errorCode, message)`;
-      - Added factory `BadRequestException.Factory.CreateRequired(property)`;
-      - Added factory `PropertyException.Factory.CreateRequired(property)`;
-      - Added factory `UnauthorizedException.Factory.Create(property, errorCode)`;
-      - Added factory `ForbiddenException.Factory.Create(property, errorCode)`;
-      - Added factory `NotFoundException.Factory.Create(property, errorCode)`;
-      - Added factory `ConflictException.Factory.Create(property, errorCode)`;
-      - Added Throw `BadRequestException.ThrowRequired(property)`;
-      - Added Throw `PropertyException.ThrowRequired(property)`;
-      - Added Throw `UnauthorizedException.Throw(property, errorCode)`;
-      - Added Throw `ForbiddenException.Throw(property, errorCode)`;
-      - Added Throw `NotFoundException.Throw(property, errorCode)`;
-      - Added Throw `ConflictException.Throw(property, errorCode)`;
+      - Added Guard `Guard.Validate.IfEquals()`;
+      - Added Guard `Guard.Validate.IfDifferent()`;
+      - Discontinued the validation `string.IfLengthZero`, Can use the `string.IfEmpty` because it does the same validation;
+      - Discontinued the validation `string.IfLengthDifference`, Can use the `string.IfLengthDifferent` because the name is wrong;
+      - Discontinued the validation `string.IfLengthGreaterThan`, Can use the `string.IfLongerThan`. Improved method name;
+      - Discontinued the validation `string.IfLengthLessThan`, Can use the `string.IfShorterThan`. Improved method name;
+      - Discontinued the validation `string.NotEmail`, Can use the `string.IfNotEmail` because the name is wrong;
     </PackageReleaseNotes>
     <Summary>Helpers, extensions and utilities to work with guard clause</Summary>
     <PackageTags>PowerUtils;Utils;Helpers;GuardClauses;Validations;Exception;Extensions;Errors</PackageTags>

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationDateTimeExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationDateTimeExtensionsTests.cs
@@ -338,4 +338,195 @@ public class GuardValidationDateTimeExtensionsTests
         act.Should()
             .BeNull();
     }
+
+
+
+    [Fact]
+    public void IfEquals_Equals_Exception()
+    {
+        // Arrange
+        var dateOfBirth = new DateTime(2000, 12, 31);
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(dateOfBirth), "INVALID");
+    }
+
+    [Fact]
+    public void IfEquals_Different_Valid()
+    {
+        // Arrange
+        var dateOfBirth = new DateTime(2021, 1, 1);
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfEqualsNullable_Null_Valid()
+    {
+        // Arrange
+        DateTime? dateOfBirth = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfEqualsNullable_BothNull_Exception()
+    {
+        // Arrange
+        DateTime? dateOfBirth = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(dateOfBirth, null));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(dateOfBirth), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Equals_Exception()
+    {
+        // Arrange
+        DateTime? dateOfBirth = new DateTime(2000, 12, 31);
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(dateOfBirth), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Different_Valid()
+    {
+        // Arrange
+        DateTime? dateOfBirth = new DateTime(2021, 1, 1);
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfDifferent_Equals_Valid()
+    {
+        // Arrange
+        var dateOfBirth = new DateTime(2000, 12, 31);
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferent_Different_Exception()
+    {
+        // Arrange
+        var dateOfBirth = new DateTime(2021, 1, 1);
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(dateOfBirth), "INVALID");
+    }
+
+
+    [Fact]
+    public void IfDifferentNullable_Null_Exception()
+    {
+        // Arrange
+        DateTime? dateOfBirth = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(dateOfBirth), "INVALID");
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Equals_Valid()
+    {
+        // Arrange
+        DateTime? dateOfBirth = new DateTime(2000, 12, 31);
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Different_Exception()
+    {
+        // Arrange
+        DateTime? dateOfBirth = new DateTime(2021, 1, 1);
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(dateOfBirth, new DateTime(2000, 12, 31)));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(dateOfBirth), "INVALID");
+    }
+
+    [Fact]
+    public void IfDifferentNullable_BothNull_Valid()
+    {
+        // Arrange
+        DateTime? dateOfBirth = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(dateOfBirth, null));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationDecimalExtensions.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationDecimalExtensions.cs
@@ -170,4 +170,164 @@ public class GuardValidationDecimalExtensionsTests
         act.Should()
             .BeNull();
     }
+
+
+
+    [Fact]
+    public void IfEquals_Equals_Exception()
+    {
+        // Arrange
+        decimal quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEquals_Different_Valid()
+    {
+        // Arrange
+        decimal quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 6));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfEqualsNullable_Null_Valid()
+    {
+        // Arrange
+        decimal? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Equals_Exception()
+    {
+        // Arrange
+        decimal? quantity = 4;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Different_Valid()
+    {
+        // Arrange
+        decimal? quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfDifferent_Equals_Valid()
+    {
+        // Arrange
+        decimal quantity = 22;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 22));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferent_Different_Exception()
+    {
+        // Arrange
+        decimal quantity = 51;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 12));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+
+    [Fact]
+    public void IfDifferentNullable_Null_Exception()
+    {
+        // Arrange
+        decimal? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 74));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Equals_Valid()
+    {
+        // Arrange
+        decimal? quantity = 78;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 78));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Different_Exception()
+    {
+        // Arrange
+        decimal? quantity = 45;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 321));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationDoubleExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationDoubleExtensionsTests.cs
@@ -170,4 +170,163 @@ public class GuardValidationDoubleExtensionsTests
         act.Should()
             .BeNull();
     }
+
+
+    [Fact]
+    public void IfEquals_Equals_Exception()
+    {
+        // Arrange
+        double quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEquals_Different_Valid()
+    {
+        // Arrange
+        double quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 6));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfEqualsNullable_Null_Valid()
+    {
+        // Arrange
+        double? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Equals_Exception()
+    {
+        // Arrange
+        double? quantity = 4;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Different_Valid()
+    {
+        // Arrange
+        double? quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfDifferent_Equals_Valid()
+    {
+        // Arrange
+        double quantity = 22;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 22));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferent_Different_Exception()
+    {
+        // Arrange
+        double quantity = 51;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 12));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+
+    [Fact]
+    public void IfDifferentNullable_Null_Exception()
+    {
+        // Arrange
+        double? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 74));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Equals_Valid()
+    {
+        // Arrange
+        double? quantity = 78;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 78));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Different_Exception()
+    {
+        // Arrange
+        double? quantity = 45;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 321));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationGuidExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationGuidExtensionsTests.cs
@@ -39,4 +39,193 @@ public class GuardValidationGuidExtensionsTests
         act.Should()
             .BeNull();
     }
+
+    [Fact]
+    public void IfEquals_Equals_Exception()
+    {
+        // Arrange
+        var id = Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02");
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(id, Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02")));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(id), "INVALID");
+    }
+
+    [Fact]
+    public void IfEquals_Different_Valid()
+    {
+        // Arrange
+        var id = Guid.Parse("ec243094-2d85-41a5-bd15-ce8f3af96b96");
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(id, Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02")));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfEqualsNullable_Null_Valid()
+    {
+        // Arrange
+        Guid? id = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(id, Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02")));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfEqualsNullable_BothNull_Exception()
+    {
+        // Arrange
+        Guid? id = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(id, null));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(id), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Equals_Exception()
+    {
+        // Arrange
+        Guid? id = Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02");
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(id, Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02")));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(id), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Different_Valid()
+    {
+        // Arrange
+        Guid? id = Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02");
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(id, Guid.Parse("ec243094-2d85-41a5-bd15-ce8f3af96b96")));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfDifferent_Equals_Valid()
+    {
+        // Arrange
+        Guid? id = Guid.Parse("ec243094-2d85-41a5-bd15-ce8f3af96b96");
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(id, Guid.Parse("ec243094-2d85-41a5-bd15-ce8f3af96b96")));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferent_Different_Exception()
+    {
+        // Arrange
+        Guid? id = Guid.Parse("ec243094-2d85-41a5-bd15-ce8f3af96b96");
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(id, Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02")));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(id), "INVALID");
+    }
+
+
+    [Fact]
+    public void IfDifferentNullable_Null_Exception()
+    {
+        // Arrange
+        Guid? id = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(id, Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02")));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(id), "INVALID");
+    }
+
+    [Fact]
+    public void IfDifferentNullable_BothNull_Exception()
+    {
+        // Arrange
+        Guid? id = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(id, null));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Equals_Valid()
+    {
+        // Arrange
+        Guid? id = Guid.Parse("ec243094-2d85-41a5-bd15-ce8f3af96b96");
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(id, Guid.Parse("ec243094-2d85-41a5-bd15-ce8f3af96b96")));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Different_Exception()
+    {
+        // Arrange
+        Guid? id = Guid.Parse("ec243094-2d85-41a5-bd15-ce8f3af96b96");
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(id, Guid.Parse("dd348c71-3115-493f-873c-03bd4ccfae02")));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(id), "INVALID");
+    }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationIntExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationIntExtensionsTests.cs
@@ -170,4 +170,163 @@ public class GuardValidationIntExtensionsTests
         act.Should()
             .BeNull();
     }
+
+
+    [Fact]
+    public void IfEquals_Equals_Exception()
+    {
+        // Arrange
+        var quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEquals_Different_Valid()
+    {
+        // Arrange
+        var quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 6));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfEqualsNullable_Null_Valid()
+    {
+        // Arrange
+        int? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Equals_Exception()
+    {
+        // Arrange
+        int? quantity = 4;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Different_Valid()
+    {
+        // Arrange
+        int? quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfDifferent_Equals_Valid()
+    {
+        // Arrange
+        var quantity = 22;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 22));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferent_Different_Exception()
+    {
+        // Arrange
+        var quantity = 51;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 12));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+
+    [Fact]
+    public void IfDifferentNullable_Null_Exception()
+    {
+        // Arrange
+        int? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 74));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Equals_Valid()
+    {
+        // Arrange
+        int? quantity = 78;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 78));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Different_Exception()
+    {
+        // Arrange
+        int? quantity = 45;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 321));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationLongExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationLongExtensionsTests.cs
@@ -170,4 +170,163 @@ public class GuardValidationLongExtensionsTests
         act.Should()
             .BeNull();
     }
+
+
+    [Fact]
+    public void IfEquals_Equals_Exception()
+    {
+        // Arrange
+        long quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEquals_Different_Valid()
+    {
+        // Arrange
+        long quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 6));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfEqualsNullable_Null_Valid()
+    {
+        // Arrange
+        long? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Equals_Exception()
+    {
+        // Arrange
+        long? quantity = 4;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Different_Valid()
+    {
+        // Arrange
+        long? quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfDifferent_Equals_Valid()
+    {
+        // Arrange
+        long quantity = 22;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 22));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferent_Different_Exception()
+    {
+        // Arrange
+        long quantity = 51;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 12));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+
+    [Fact]
+    public void IfDifferentNullable_Null_Exception()
+    {
+        // Arrange
+        long? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 74));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Equals_Valid()
+    {
+        // Arrange
+        long? quantity = 78;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 78));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Different_Exception()
+    {
+        // Arrange
+        long? quantity = 45;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 321));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationShortExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationShortExtensionsTests.cs
@@ -5,17 +5,17 @@ using PowerUtils.Validations.GuardClauses;
 namespace PowerUtils.GuardClauses.Validations.Tests.GuardClausesTests;
 
 [Trait("Type", "Guards")]
-public class GuardValidationFloatExtensionsTests
+public class GuardValidationShortExtensionsTests
 {
     [Fact]
     public void IfGreaterThan_LargeNumber_Exception()
     {
         // Arrange
-        var quantity = 241f;
+        short quantity = 241;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -26,11 +26,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfGreaterThan_NotLargeNumber_Valid()
     {
         // Arrange
-        var quantity = 4f;
+        short quantity = 4;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -44,11 +44,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfGreaterThanNullable_Null_Valid()
     {
         // Arrange
-        float? quantity = null;
+        short? quantity = null;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -61,11 +61,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfGreaterThanNullable_LargeNumber_Exception()
     {
         // Arrange
-        float? quantity = 241;
+        short? quantity = 241;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -76,11 +76,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfGreaterThanNullable_NotLargeNumber_Valid()
     {
         // Arrange
-        float? quantity = 4;
+        short? quantity = 4;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -94,11 +94,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThan_SmallNumber_Exception()
     {
         // Arrange
-        var quantity = 4f;
+        short quantity = 4;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -109,11 +109,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThan_NotSmallNumber_Valid()
     {
         // Arrange
-        var quantity = 14f;
+        short quantity = 14;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -127,11 +127,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThanNullable_Null_Valid()
     {
         // Arrange
-        float? quantity = null;
+        short? quantity = null;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -144,11 +144,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThanNullable_SmallNumber_Exception()
     {
         // Arrange
-        float? quantity = 2;
+        short? quantity = 2;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -159,11 +159,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThanNullable_NotSmallNumber_Valid()
     {
         // Arrange
-        float? quantity = 45;
+        short? quantity = 45;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -172,11 +172,57 @@ public class GuardValidationFloatExtensionsTests
     }
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     [Fact]
     public void IfEquals_Equals_Exception()
     {
         // Arrange
-        float quantity = 5;
+        short quantity = 5;
 
 
         // Act
@@ -191,7 +237,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfEquals_Different_Valid()
     {
         // Arrange
-        float quantity = 5;
+        short quantity = 5;
 
 
         // Act
@@ -208,7 +254,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfEqualsNullable_Null_Valid()
     {
         // Arrange
-        float? quantity = null;
+        short? quantity = null;
 
 
         // Act
@@ -224,7 +270,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfEqualsNullable_Equals_Exception()
     {
         // Arrange
-        float? quantity = 4;
+        short? quantity = 4;
 
 
         // Act
@@ -239,7 +285,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfEqualsNullable_Different_Valid()
     {
         // Arrange
-        float? quantity = 5;
+        short? quantity = 5;
 
 
         // Act
@@ -256,7 +302,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferent_Equals_Valid()
     {
         // Arrange
-        float quantity = 22;
+        short quantity = 22;
 
 
         // Act
@@ -272,7 +318,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferent_Different_Exception()
     {
         // Arrange
-        float quantity = 51;
+        short quantity = 51;
 
 
         // Act
@@ -288,7 +334,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferentNullable_Null_Exception()
     {
         // Arrange
-        float? quantity = null;
+        short? quantity = null;
 
 
         // Act
@@ -303,7 +349,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferentNullable_Equals_Valid()
     {
         // Arrange
-        float? quantity = 78;
+        short? quantity = 78;
 
 
         // Act
@@ -319,7 +365,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferentNullable_Different_Exception()
     {
         // Arrange
-        float? quantity = 45;
+        short? quantity = 45;
 
 
         // Act

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationStringExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationStringExtensionsTests.cs
@@ -425,7 +425,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.NotEmail(clientEmail));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -440,7 +442,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.NotEmail(clientEmail));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -455,7 +459,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.NotEmail(clientEmail));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -470,7 +476,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.NotEmail(clientEmail));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -485,7 +493,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.NotEmail(clientEmail));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -826,5 +836,180 @@ public class GuardValidationStringExtensionsTests
 
         // Assert
         act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "MIN:5");
+    }
+
+
+    [Fact]
+    public void IfEquals_Equals_Exception()
+    {
+        // Arrange
+        var client = "Fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(client, "Fake"));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "INVALID");
+    }
+
+    [Fact]
+    public void IfEquals_Different_Valid()
+    {
+        // Arrange
+        var client = "Fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(client, "fake fake"));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfEquals_Null_Valid()
+    {
+        // Arrange
+        string client = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(client, "fake fake"));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfDifferent_Equals_Valid()
+    {
+        // Arrange
+        var client = "fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(client, "fake"));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferent_Different_Exception()
+    {
+        // Arrange
+        var client = "fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(client, "fake fake"));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "INVALID");
+    }
+
+
+    [Fact]
+    public void IfDifferent_Null_Exception()
+    {
+        // Arrange
+        string client = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(client, "fake"));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "INVALID");
+    }
+
+
+
+    [Fact]
+    public void IfNotEmail_Null_Exception()
+    {
+        // Arrange
+        string clientEmail = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfNotEmail(clientEmail));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(clientEmail), "INVALID");
+    }
+
+    [Fact]
+    public void IfNotEmail_Empty_Exception()
+    {
+        // Arrange
+        var clientEmail = "";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfNotEmail(clientEmail));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(clientEmail), "INVALID");
+    }
+
+    [Fact]
+    public void IfNotEmail_WithSpace_Exception()
+    {
+        // Arrange
+        var clientEmail = "    ";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfNotEmail(clientEmail));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(clientEmail), "INVALID");
+    }
+
+    [Fact]
+    public void IfNotEmail_FakeText_Exception()
+    {
+        // Arrange
+        var clientEmail = "fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfNotEmail(clientEmail));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(clientEmail), "INVALID");
+    }
+
+    [Fact]
+    public void IfNotEmail_Email_Valid()
+    {
+        // Arrange
+        var clientEmail = "fake@fake.tk";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfNotEmail(clientEmail));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
     }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationStringExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationStringExtensionsTests.cs
@@ -142,27 +142,6 @@ public class GuardValidationStringExtensionsTests
             .BeNull();
     }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     [Fact]
     public void IfNullOrEmpty_Null_Exception()
     {
@@ -381,7 +360,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthZero(client));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -397,7 +378,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthZero(client));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -412,7 +395,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthZero(client));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -583,7 +568,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthDifference(client, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -598,7 +585,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthDifference(client, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -613,7 +602,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthDifference(client, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -628,7 +619,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthDifference(client, 6));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -643,7 +636,85 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthDifference(client, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfLengthDifferent_Null_Exception()
+    {
+        // Arrange
+        string client = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfLengthDifferent(client, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "INVALID");
+    }
+
+    [Fact]
+    public void IfLengthDifferent_Empty_Exception()
+    {
+        // Arrange
+        var client = "";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfLengthDifferent(client, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "INVALID");
+    }
+
+    [Fact]
+    public void IfLengthDifferent_4Length_Exception()
+    {
+        // Arrange
+        var client = "fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfLengthDifferent(client, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "INVALID");
+    }
+
+    [Fact]
+    public void IfLengthDifferent_6Length_Exception()
+    {
+        // Arrange
+        var client = "fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfLengthDifferent(client, 6));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "INVALID");
+    }
+
+    [Fact]
+    public void IfLengthDifferent_5Length_Valid()
+    {
+        // Arrange
+        var client = "fakes";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfLengthDifferent(client, 5));
 
 
         // Assert

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationStringExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationStringExtensionsTests.cs
@@ -262,7 +262,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthGreaterThan(client, 1));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -278,7 +280,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthGreaterThan(client, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -293,7 +297,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthGreaterThan(client, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -311,7 +317,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthLessThan(client, 1));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -327,7 +335,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthLessThan(client, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -342,7 +352,9 @@ public class GuardValidationStringExtensionsTests
 
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var act = Record.Exception(() => Guard.Validate.IfLengthLessThan(client, 5));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 
         // Assert
@@ -720,5 +732,99 @@ public class GuardValidationStringExtensionsTests
         // Assert
         act.Should()
             .BeNull();
+    }
+
+    [Fact]
+    public void IfLongerThan_Null_Valid()
+    {
+        // Arrange
+        string client = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfLongerThan(client, 1));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfLongerThan_BigText_Exception()
+    {
+        // Arrange
+        var client = "Fake fake fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfLongerThan(client, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "MAX:5");
+    }
+
+    [Fact]
+    public void IfLongerThan_ShortText_Valid()
+    {
+        // Arrange
+        var client = "Fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfLongerThan(client, 5));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfShorterThan_Null_Valid()
+    {
+        // Arrange
+        string client = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfShorterThan(client, 1));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfShorterThan_BigText_Valid()
+    {
+        // Arrange
+        var client = "Fake fake fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfShorterThan(client, 5));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfShorterThan_ShortText_Exception()
+    {
+        // Arrange
+        var client = "Fake";
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfShorterThan(client, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(client), "MIN:5");
     }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationUIntExtensions.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationUIntExtensions.cs
@@ -170,4 +170,163 @@ public class GuardValidationUIntExtensions
         act.Should()
             .BeNull();
     }
+
+
+    [Fact]
+    public void IfEquals_Equals_Exception()
+    {
+        // Arrange
+        uint quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEquals_Different_Valid()
+    {
+        // Arrange
+        uint quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 6));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfEqualsNullable_Null_Valid()
+    {
+        // Arrange
+        uint? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Equals_Exception()
+    {
+        // Arrange
+        uint? quantity = 4;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Different_Valid()
+    {
+        // Arrange
+        uint? quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfDifferent_Equals_Valid()
+    {
+        // Arrange
+        uint quantity = 22;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 22));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferent_Different_Exception()
+    {
+        // Arrange
+        uint quantity = 51;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 12));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+
+    [Fact]
+    public void IfDifferentNullable_Null_Exception()
+    {
+        // Arrange
+        uint? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 74));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Equals_Valid()
+    {
+        // Arrange
+        uint? quantity = 78;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 78));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Different_Exception()
+    {
+        // Arrange
+        uint? quantity = 45;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 321));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationULongExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationULongExtensionsTests.cs
@@ -170,4 +170,163 @@ public class GuardValidationULongExtensionsTests
         act.Should()
             .BeNull();
     }
+
+
+    [Fact]
+    public void IfEquals_Equals_Exception()
+    {
+        // Arrange
+        ulong quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEquals_Different_Valid()
+    {
+        // Arrange
+        ulong quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 6));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfEqualsNullable_Null_Valid()
+    {
+        // Arrange
+        ulong? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 5));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Equals_Exception()
+    {
+        // Arrange
+        ulong? quantity = 4;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfEqualsNullable_Different_Valid()
+    {
+        // Arrange
+        ulong? quantity = 5;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfEquals(quantity, 4));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+
+    [Fact]
+    public void IfDifferent_Equals_Valid()
+    {
+        // Arrange
+        ulong quantity = 22;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 22));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferent_Different_Exception()
+    {
+        // Arrange
+        ulong quantity = 51;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 12));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+
+    [Fact]
+    public void IfDifferentNullable_Null_Exception()
+    {
+        // Arrange
+        ulong? quantity = null;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 74));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Equals_Valid()
+    {
+        // Arrange
+        ulong? quantity = 78;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 78));
+
+
+        // Assert
+        act.Should()
+            .BeNull();
+    }
+
+    [Fact]
+    public void IfDifferentNullable_Different_Exception()
+    {
+        // Arrange
+        ulong? quantity = 45;
+
+
+        // Act
+        var act = Record.Exception(() => Guard.Validate.IfDifferent(quantity, 321));
+
+
+        // Assert
+        act.Validate<PropertyException>(HttpStatusCode.BadRequest, nameof(quantity), "INVALID");
+    }
 }

--- a/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationUShortExtensionsTests.cs
+++ b/tests/PowerUtils.GuardClauses.Validations.Tests/GuardClausesTests/GuardValidationUShortExtensionsTests.cs
@@ -5,17 +5,17 @@ using PowerUtils.Validations.GuardClauses;
 namespace PowerUtils.GuardClauses.Validations.Tests.GuardClausesTests;
 
 [Trait("Type", "Guards")]
-public class GuardValidationFloatExtensionsTests
+public class GuardValidationUShortExtensionsTests
 {
     [Fact]
     public void IfGreaterThan_LargeNumber_Exception()
     {
         // Arrange
-        var quantity = 241f;
+        ushort quantity = 241;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -26,11 +26,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfGreaterThan_NotLargeNumber_Valid()
     {
         // Arrange
-        var quantity = 4f;
+        ushort quantity = 4;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -44,11 +44,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfGreaterThanNullable_Null_Valid()
     {
         // Arrange
-        float? quantity = null;
+        ushort? quantity = null;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -61,11 +61,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfGreaterThanNullable_LargeNumber_Exception()
     {
         // Arrange
-        float? quantity = 241;
+        ushort? quantity = 241;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -76,11 +76,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfGreaterThanNullable_NotLargeNumber_Valid()
     {
         // Arrange
-        float? quantity = 4;
+        ushort? quantity = 4;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfGreaterThan(quantity, 5));
 
 
         // Assert
@@ -94,11 +94,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThan_SmallNumber_Exception()
     {
         // Arrange
-        var quantity = 4f;
+        ushort quantity = 4;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -109,11 +109,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThan_NotSmallNumber_Valid()
     {
         // Arrange
-        var quantity = 14f;
+        ushort quantity = 14;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -127,11 +127,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThanNullable_Null_Valid()
     {
         // Arrange
-        float? quantity = null;
+        ushort? quantity = null;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -144,11 +144,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThanNullable_SmallNumber_Exception()
     {
         // Arrange
-        float? quantity = 2;
+        ushort? quantity = 2;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -159,11 +159,11 @@ public class GuardValidationFloatExtensionsTests
     public void IfLessThanNullable_NotSmallNumber_Valid()
     {
         // Arrange
-        float? quantity = 45;
+        ushort? quantity = 45;
 
 
         // Act
-        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5f));
+        var act = Record.Exception(() => Guard.Validate.IfLessThan(quantity, 5));
 
 
         // Assert
@@ -176,7 +176,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfEquals_Equals_Exception()
     {
         // Arrange
-        float quantity = 5;
+        ushort quantity = 5;
 
 
         // Act
@@ -191,7 +191,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfEquals_Different_Valid()
     {
         // Arrange
-        float quantity = 5;
+        ushort quantity = 5;
 
 
         // Act
@@ -208,7 +208,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfEqualsNullable_Null_Valid()
     {
         // Arrange
-        float? quantity = null;
+        ushort? quantity = null;
 
 
         // Act
@@ -224,7 +224,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfEqualsNullable_Equals_Exception()
     {
         // Arrange
-        float? quantity = 4;
+        ushort? quantity = 4;
 
 
         // Act
@@ -239,7 +239,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfEqualsNullable_Different_Valid()
     {
         // Arrange
-        float? quantity = 5;
+        ushort? quantity = 5;
 
 
         // Act
@@ -256,7 +256,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferent_Equals_Valid()
     {
         // Arrange
-        float quantity = 22;
+        ushort quantity = 22;
 
 
         // Act
@@ -272,7 +272,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferent_Different_Exception()
     {
         // Arrange
-        float quantity = 51;
+        ushort quantity = 51;
 
 
         // Act
@@ -288,7 +288,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferentNullable_Null_Exception()
     {
         // Arrange
-        float? quantity = null;
+        ushort? quantity = null;
 
 
         // Act
@@ -303,7 +303,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferentNullable_Equals_Valid()
     {
         // Arrange
-        float? quantity = 78;
+        ushort? quantity = 78;
 
 
         // Act
@@ -319,7 +319,7 @@ public class GuardValidationFloatExtensionsTests
     public void IfDifferentNullable_Different_Exception()
     {
         // Arrange
-        float? quantity = 45;
+        ushort? quantity = 45;
 
 
         // Act


### PR DESCRIPTION
## [1.2.0] - 2022-03-20
[Full Changelog](https://github.com/TechNobre/PowerUtils.GuardClauses.Validations/compare/v1.1.0...v1.2.0)


### New Features
- Added Guard `Guard.Validate.IfEquals()`;
- Added Guard `Guard.Validate.IfDifferent()`;


### Enhancements
- Discontinued the validation `string.IfLengthZero`, Can use the `string.IfEmpty` because it does the same validation;
- Discontinued the validation `string.IfLengthDifference`, Can use the `string.IfLengthDifferent` because the name is wrong;
- Discontinued the validation `string.IfLengthGreaterThan`, Can use the `string.IfLongerThan`. Improved method name;
- Discontinued the validation `string.IfLengthLessThan`, Can use the `string.IfShorterThan`. Improved method name;
- Discontinued the validation `string.NotEmail`, Can use the `string.IfNotEmail` because the name is wrong;